### PR TITLE
jsonf: removed unnecessary PYGMENTS_AVAILABLE flag

### DIFF
--- a/jsonformat/jsonf/cli.py
+++ b/jsonformat/jsonf/cli.py
@@ -21,9 +21,8 @@ try:
     from pygments import highlight
     from pygments.lexers import JSONLexer
     from pygments.formatters import TerminalFormatter
-    PYGMENTS_AVAILABLE = True
 except ImportError:
-    PYGMENTS_AVAILABLE = False
+    pass
 
 
 def format_json(data):
@@ -48,9 +47,9 @@ def main():
 
     print ''.join(headers)
     output = format_json(''.join(content))
-    if PYGMENTS_AVAILABLE:
+    try:
         print highlight(output, JSONLexer(), TerminalFormatter())
-    else:
+    except NameError:
         print output
         print >>stderr, ("NOTE: If you have the python package "
                          "`pygments` available for import, you'll get nice "


### PR DESCRIPTION
seems more Pythonic this way

also, I've noticed that
- `jsonf` might as well be a simple module (file) rather than a package (directory) - but I didn't change that in case you have bigger plans
- `headers_done` seems unused, but I didn't change that either as I'd rather rewrite that block entirely
